### PR TITLE
Files

### DIFF
--- a/src/com/multicraft/CustomUndoStack.java
+++ b/src/com/multicraft/CustomUndoStack.java
@@ -26,7 +26,21 @@ public class CustomUndoStack {
 		dataArr[insertIndex] = null;
 		return data;		 
 	}
-	
+
+	public BuildCommandData peek() throws NoCommandHistoryException {
+		if(this.isEmpty()) {
+			throw new NoCommandHistoryException("The stack is empty.");
+		}
+
+		int peekIndex = insertIndex - 1;
+
+		if(peekIndex < 0) {
+			peekIndex = this.size-1;
+		}
+
+		return dataArr[peekIndex];
+	}
+
 	public void push(BuildCommandData data) {
 		this.dataArr[this.insertIndex] = data;
 		this.insertIndex+=1;
@@ -44,12 +58,8 @@ public class CustomUndoStack {
 		
 		if(indexToCheck < 0)
 			indexToCheck = this.size-1;
-		
-		if(dataArr[indexToCheck] == null) {
-			return true;
-		}
-		
-		return false;
+
+		return dataArr[indexToCheck] == null;
 	}
 	
 	public int getSize() {

--- a/src/com/multicraft/FileThread.java
+++ b/src/com/multicraft/FileThread.java
@@ -1,0 +1,38 @@
+package com.multicraft;
+
+import java.io.*;
+import java.net.Socket;
+
+public class FileThread extends Thread{
+	protected Socket socket;
+	MultiCraft plugin;
+	private final String jarLocation;
+	public FileThread(Socket clientSocket, MultiCraft pl) {
+		socket = clientSocket;
+		plugin = pl;
+		File filePath = new File(FileThread.class.getProtectionDomain().getCodeSource().getLocation().getPath());
+		jarLocation = filePath.getPath().substring(0, filePath.getPath().indexOf(filePath.getName()));
+	}
+
+	public void run() {
+		try {
+			DataInputStream dis = new DataInputStream(socket.getInputStream());
+			File f = new File(jarLocation + "\\MultiCraft\\" + socket.getInetAddress().getHostAddress() + "Gaze.csv");
+			if (!f.exists()) {
+				f.getParentFile().mkdirs();
+				f.createNewFile();
+			}
+			FileOutputStream fos = new FileOutputStream(f, true);
+			while (!socket.isClosed()) {
+				byte[] b = new byte[dis.available()];
+				dis.readFully(b);
+				fos.write(b);
+			}
+			dis.close();
+			fos.close();
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+	}
+}
+

--- a/src/com/multicraft/FileTransferServer.java
+++ b/src/com/multicraft/FileTransferServer.java
@@ -1,0 +1,40 @@
+package com.multicraft;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.net.Socket;
+
+
+/*
+ * This Server handles socket connections for each client. One server receives connection requests and for each,
+ * creates a unique EchoThread instance to communicate with that particular client
+ */
+
+public class FileTransferServer extends Thread{
+
+	MultiCraft plugin;
+
+	public FileTransferServer(MultiCraft pl) {
+		plugin = pl;
+	}
+
+	@SuppressWarnings("resource")
+	public void run() {
+		ServerSocket serverSocket = null;
+		Socket socket = null;
+		try {
+			serverSocket = new ServerSocket(5004);
+		}catch(IOException e) {
+			e.printStackTrace();
+		}
+
+		while(true) {
+			try {
+				socket = serverSocket.accept();
+			}catch(IOException e) {
+				e.printStackTrace();
+			}
+			new FileThread(socket, plugin).start();
+		}
+	}
+}

--- a/src/com/multicraft/MultiCraft.java
+++ b/src/com/multicraft/MultiCraft.java
@@ -32,6 +32,9 @@ public class MultiCraft extends JavaPlugin{
 		new SpeechToTextServer(this).start();
 		new CommandsListener(this).start();
 		new CommandExecution(this).start();
+
+		// start thread to handle file transfers
+		new FileTransferServer(this).start();
 	}
 	
 	@Override

--- a/src/com/multicraft/MultiCraftCommandExecutor.java
+++ b/src/com/multicraft/MultiCraftCommandExecutor.java
@@ -10,7 +10,6 @@ import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
-import org.bukkit.scheduler.BukkitRunnable;
 import com.multicraft.Materials.MaterialDoesNotExistException;
 
 
@@ -238,7 +237,7 @@ public class MultiCraftCommandExecutor implements CommandExecutor {
 				StructureData playerStructureData = new StructureData(jarLocation + "\\MultiCraft\\" + p.getUniqueId() + "StructureData.csv");
 
 				BuildCommandData playerBuildData;
-				try { playerBuildData = PreviousBuildsData.getInstance().getPlayersBuildRecordForUndo(p); }
+				try { playerBuildData = PreviousBuildsData.getInstance().getPlayersLastBuildRecord(p); }
 				catch(NoCommandHistoryException e) {
 					p.sendMessage("No previous builds found.");
 					break;

--- a/src/com/multicraft/MultiCraftCommandExecutor.java
+++ b/src/com/multicraft/MultiCraftCommandExecutor.java
@@ -234,8 +234,8 @@ public class MultiCraftCommandExecutor implements CommandExecutor {
 					break;
 				}
 
-				StructureData universalStructureData = new StructureData(jarLocation + "universal" + "StructureData.csv");
-				StructureData playerStructureData = new StructureData(jarLocation + p.getUniqueId() + "StructureData.csv");
+				StructureData universalStructureData = new StructureData(jarLocation + "\\MultiCraft\\" + "universal" + "StructureData.csv");
+				StructureData playerStructureData = new StructureData(jarLocation + "\\MultiCraft\\" + p.getUniqueId() + "StructureData.csv");
 
 				BuildCommandData playerBuildData;
 				try { playerBuildData = PreviousBuildsData.getInstance().getPlayersBuildRecordForUndo(p); }
@@ -283,8 +283,8 @@ public class MultiCraftCommandExecutor implements CommandExecutor {
 					break;
 				}
 
-				StructureData universalStructureData = new StructureData(jarLocation + "universal" + "StructureData.csv");
-				StructureData playerStructureData = new StructureData(jarLocation + p.getUniqueId() + "StructureData.csv");
+				StructureData universalStructureData = new StructureData(jarLocation + "\\MultiCraft\\" + "universal" + "StructureData.csv");
+				StructureData playerStructureData = new StructureData(jarLocation + "\\MultiCraft\\" + p.getUniqueId() + "StructureData.csv");
 
 				// check for player-stored structure first, then universal
 				String[] buildData = playerStructureData.getStructureData(args[0]);

--- a/src/com/multicraft/PreviousBuildsData.java
+++ b/src/com/multicraft/PreviousBuildsData.java
@@ -48,7 +48,7 @@ public class PreviousBuildsData {
 		}
 
 		CustomUndoStack tempStack = buildsUndoData.get(p.getUniqueId());
-		temp = tempStack.pop();
+		temp = tempStack.peek();
 		// temp = instance.buildsUndoData.get(p).pop();
 		return temp;
 	}

--- a/src/com/multicraft/PreviousBuildsData.java
+++ b/src/com/multicraft/PreviousBuildsData.java
@@ -48,17 +48,23 @@ public class PreviousBuildsData {
 		}
 
 		CustomUndoStack tempStack = buildsUndoData.get(p.getUniqueId());
-		temp = tempStack.peek();
+		temp = tempStack.pop();
 		// temp = instance.buildsUndoData.get(p).pop();
 		return temp;
+	}
+
+	public BuildCommandData getPlayersLastBuildRecord(Player p) throws NoCommandHistoryException{
+		if(! buildsUndoData.containsKey(p.getUniqueId())) {
+			throw new NoCommandHistoryException("Player is not in the dictionary.");
+		}
+		CustomUndoStack tempStack = buildsUndoData.get(p.getUniqueId());
+		return tempStack.peek();
 	}
 	
 	public BuildCommandData getPlayersBuildRecordForRedo(Player p) throws NoCommandHistoryException{
 		if(! buildsRedoData.containsKey(p.getUniqueId()))
 			throw new NoCommandHistoryException("Player is not in the redo dictionary.");
-		BuildCommandData temp = null;
-		temp = instance.buildsRedoData.get(p.getUniqueId()).pop();
-		return temp;
+		return instance.buildsRedoData.get(p.getUniqueId()).pop();
 	}
 	
 	public void addToRedoStack(Player p, BuildCommandData data) {

--- a/src/com/multicraft/StructureData.java
+++ b/src/com/multicraft/StructureData.java
@@ -31,6 +31,7 @@ public class StructureData {
             File structureFile = new File(path);
             HashMap<String, String[]> csvData = new HashMap<>();
             try {
+                structureFile.getParentFile().mkdirs();
                 if (!structureFile.createNewFile()) {
                     try (BufferedReader br = new BufferedReader(new FileReader(path))) {
                         String line;


### PR DESCRIPTION
Add FileTransferServer.java and FileThread.java for accepting gaze data files from MultiCraft clients.
External files written to by the plugin are now all stored in a `MultiCraft` subdirectory.
Also updated an old bug with mstore that broke build data stacks for mundo commands.